### PR TITLE
Added flag to disable the fade-in effect

### DIFF
--- a/FXImageView/FXImageView.h
+++ b/FXImageView/FXImageView.h
@@ -39,6 +39,7 @@
 + (NSCache *)processedImageCache;
 
 @property (nonatomic, assign, getter = isAsynchronous) BOOL asynchronous;
+@property (nonatomic, assign, getter = isAnimated) BOOL animated;
 @property (nonatomic, assign) CGFloat reflectionGap;
 @property (nonatomic, assign) CGFloat reflectionScale;
 @property (nonatomic, assign) CGFloat reflectionAlpha;

--- a/FXImageView/FXImageView.m
+++ b/FXImageView/FXImageView.m
@@ -81,6 +81,7 @@
 @implementation FXImageView
 
 @synthesize asynchronous = _asynchronous;
+@synthesize animated = _animated;
 @synthesize reflectionGap = _reflectionGap;
 @synthesize reflectionScale = _reflectionScale;
 @synthesize reflectionAlpha = _reflectionAlpha;
@@ -126,6 +127,7 @@
 
 - (void)setUp
 {
+	_animated = YES;
     self.shadowColor = [UIColor blackColor];
     _imageView = [[UIImageView alloc] initWithFrame:self.bounds];
     _imageView.contentMode = UIViewContentModeCenter;
@@ -265,9 +267,12 @@
     if ([[self cacheKey] isEqualToString:cacheKey])
     {
         //implement crossfade transition without needing to import QuartzCore
-        id animation = objc_msgSend(NSClassFromString(@"CATransition"), @selector(animation));
-        objc_msgSend(animation, @selector(setType:), @"kCATransitionFade");
-        objc_msgSend(self.layer, @selector(addAnimation:forKey:), animation, nil);
+		if (_animated)
+		{
+			id animation = objc_msgSend(NSClassFromString(@"CATransition"), @selector(animation));
+			objc_msgSend(animation, @selector(setType:), @"kCATransitionFade");
+			objc_msgSend(self.layer, @selector(addAnimation:forKey:), animation, nil);
+		}
         
         //set processed image
         [self willChangeValueForKey:@"processedImage"];


### PR DESCRIPTION
Hi Nick,
I found out a problem with iCarousel and FXImageView, due to the two fade-in animations on iCarousel and FXImageView starting at the same time and conflicting each other.

I added a new flag to disable the fade-in effect on FXImageView.
I set it to be enabled by default so to keep the code 100% backward compatible.

Cheers,
Andrea
